### PR TITLE
Add FieldResolver interface to match options

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -36,3 +36,81 @@ detection:
 	// Rule: My example rule
 	// Matches? true
 }
+
+// ExampleResolver demonstrates custom field resolution
+type ExampleResolver struct{}
+
+func (r *ExampleResolver) Resolve(fieldName string, entry *sigma.LogEntry) []string {
+	switch fieldName {
+	case "process.users":
+		// This could query nested JSON, arrays, wildcards, etc.
+		// For this example, we'll simulate extracting users from different fields
+		var users []string
+		if user, ok := entry.Fields["Event.Process.User"]; ok {
+			users = append(users, user)
+		}
+		if user, ok := entry.Fields["Event.Login.User"]; ok {
+			users = append(users, user)
+		}
+		if user, ok := entry.Fields["Event.Session.User"]; ok {
+			users = append(users, user)
+		}
+		return users
+	default:
+		return nil
+	}
+}
+
+func Example_fieldResolver() {
+	// Example demonstrating custom field resolution
+	rule, err := sigma.ParseRule([]byte(`
+title: Field Resolver Example
+detection:
+  selection:
+    process.users: "administrator"
+  condition: selection
+`))
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		return
+	}
+
+	resolver := &ExampleResolver{}
+	opts := &sigma.MatchOptions{
+		FieldResolver: resolver,
+	}
+
+	// This entry will match because the resolver finds "administrator" in Event.Process.User
+	entry1 := &sigma.LogEntry{
+		Fields: map[string]string{
+			"Event.Process.User": "administrator",
+			"Event.Process.Name": "cmd.exe",
+		},
+	}
+
+	// This entry will also match because the resolver finds "administrator" in Event.Session.User
+	entry2 := &sigma.LogEntry{
+		Fields: map[string]string{
+			"Event.Session.User": "administrator",
+			"Event.Session.Type": "Remote",
+		},
+	}
+
+	// This entry won't match because no user field contains "administrator"
+	entry3 := &sigma.LogEntry{
+		Fields: map[string]string{
+			"Event.Process.User": "regular_user",
+			"Event.Login.User":   "guest_user",
+		},
+	}
+
+	fmt.Println("Rule:", rule.Title)
+	fmt.Println("Entry 1 matches?", rule.Detection.Matches(entry1, opts))
+	fmt.Println("Entry 2 matches?", rule.Detection.Matches(entry2, opts))
+	fmt.Println("Entry 3 matches?", rule.Detection.Matches(entry3, opts))
+	// Output:
+	// Rule: Field Resolver Example
+	// Entry 1 matches? true
+	// Entry 2 matches? true
+	// Entry 3 matches? false
+}


### PR DESCRIPTION
The `FieldResolver` interface extends the standard Sigma specification to support complex field lookup scenarios that go beyond simple key/value pairs. This allows you to implement custom field resolution logic for:

- **Nested JSON structures**: Access deeply nested fields using dot notation (e.g., `event.process.user`)
- **Array handling**: Extract values from arrays or lists within log entries
- **Wildcard matching**: Support field patterns like `process.*.user` or `network[*].ip`
- **Multiple field aggregation**: Combine values from multiple related fields
- **Case normalization**: Handle field name variations and case sensitivity
- **Complex data transformations**: Apply custom logic before field matching
- **External datasource lookups**: Lookup field values from an external datasource.