### PR TITLE
feat: add explain-like feature to sigma lib

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -29,7 +29,7 @@ detection:
 			"EventId": "1234",
 		},
 	}
-	isMatch := rule.Detection.Matches(entry, nil)
+	isMatch := rule.Detection.Matches(entry, nil).Matched
 	fmt.Println("Rule:", rule.Title)
 	fmt.Println("Matches?", isMatch)
 	// Output:
@@ -105,12 +105,37 @@ detection:
 	}
 
 	fmt.Println("Rule:", rule.Title)
-	fmt.Println("Entry 1 matches?", rule.Detection.Matches(entry1, opts))
-	fmt.Println("Entry 2 matches?", rule.Detection.Matches(entry2, opts))
-	fmt.Println("Entry 3 matches?", rule.Detection.Matches(entry3, opts))
+	fmt.Println("Entry 1 matches?", rule.Detection.Matches(entry1, opts).Matched)
+	fmt.Println("Entry 2 matches?", rule.Detection.Matches(entry2, opts).Matched)
+	fmt.Println("Entry 3 matches?", rule.Detection.Matches(entry3, opts).Matched)
 	// Output:
 	// Rule: Field Resolver Example
 	// Entry 1 matches? true
 	// Entry 2 matches? true
 	// Entry 3 matches? false
+}
+
+func Example_explain() {
+	rule, _ := sigma.ParseRule([]byte(`
+title: Admin Login Detection
+detection:
+  selection:
+    EventId: "4624"
+    User: "admin"
+  condition: selection
+`))
+
+	entry := &sigma.LogEntry{
+		Fields: map[string]string{
+			"EventId": "4624",
+			"User":    "guest",
+		},
+	}
+
+	opts := &sigma.MatchOptions{EnableExplanation: true}
+	result := rule.Detection.Matches(entry, opts)
+
+	fmt.Printf("Matched: %v\n", result.Matched)
+	fmt.Println("Explanation:")
+	fmt.Println(result.Explanation)
 }

--- a/explanation.go
+++ b/explanation.go
@@ -1,0 +1,108 @@
+// Copyright 2024 RunReveal Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sigmalite
+
+import (
+	"fmt"
+	"strings"
+)
+
+type traceNode struct {
+	Type       string
+	Name       string
+	Matched    bool
+	Field      string
+	Pattern    []string
+	FieldValue string
+	Reason     string
+	Children   []*traceNode
+}
+
+type explanationContext struct {
+	root  *traceNode
+	stack []*traceNode
+}
+
+func newExplanationContext() *explanationContext {
+	return &explanationContext{
+		stack: make([]*traceNode, 0, 16),
+	}
+}
+
+func (ctx *explanationContext) push(node *traceNode) {
+	if len(ctx.stack) > 0 {
+		parent := ctx.stack[len(ctx.stack)-1]
+		parent.Children = append(parent.Children, node)
+	} else {
+		ctx.root = node
+	}
+	ctx.stack = append(ctx.stack, node)
+}
+
+func (ctx *explanationContext) pop() {
+	if len(ctx.stack) > 0 {
+		ctx.stack = ctx.stack[:len(ctx.stack)-1]
+	}
+}
+
+func (ctx *explanationContext) Format() string {
+	if ctx.root == nil {
+		return ""
+	}
+	var sb strings.Builder
+	ctx.root.format(&sb, 0)
+	return sb.String()
+}
+
+func (node *traceNode) format(sb *strings.Builder, indent int) {
+	prefix := strings.Repeat("  ", indent)
+	symbol := "✓"
+	if !node.Matched {
+		symbol = "✗"
+	}
+
+	switch node.Type {
+	case "and":
+		sb.WriteString(fmt.Sprintf("%s[AND] %s", prefix, symbol))
+		if node.Reason != "" {
+			sb.WriteString(fmt.Sprintf(" - %s", node.Reason))
+		}
+		sb.WriteString("\n")
+	case "or":
+		sb.WriteString(fmt.Sprintf("%s[OR] %s", prefix, symbol))
+		if node.Reason != "" {
+			sb.WriteString(fmt.Sprintf(" - %s", node.Reason))
+		}
+		sb.WriteString("\n")
+	case "not":
+		sb.WriteString(fmt.Sprintf("%s[NOT] %s", prefix, symbol))
+		if node.Reason != "" {
+			sb.WriteString(fmt.Sprintf(" - %s", node.Reason))
+		}
+		sb.WriteString("\n")
+	case "named":
+		sb.WriteString(fmt.Sprintf("%s[%s] %s\n", prefix, node.Name, symbol))
+	case "atom":
+		fieldName := node.Field
+		if fieldName == "" {
+			fieldName = "<message>"
+		}
+		sb.WriteString(fmt.Sprintf("%s[%s] %s\n", prefix, fieldName, symbol))
+		if node.FieldValue != "" {
+			sb.WriteString(fmt.Sprintf("%s  Value: %q\n", prefix, node.FieldValue))
+		} else {
+			sb.WriteString(fmt.Sprintf("%s  Value: <not found>\n", prefix))
+		}
+		if len(node.Pattern) > 0 {
+			sb.WriteString(fmt.Sprintf("%s  Pattern: %v\n", prefix, node.Pattern))
+		}
+		if node.Reason != "" {
+			sb.WriteString(fmt.Sprintf("%s  Reason: %s\n", prefix, node.Reason))
+		}
+	}
+
+	for _, child := range node.Children {
+		child.format(sb, indent+1)
+	}
+}

--- a/explanation_test.go
+++ b/explanation_test.go
@@ -1,0 +1,302 @@
+// Copyright 2024 RunReveal Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+package sigmalite
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExplainBasic(t *testing.T) {
+	detection := &Detection{
+		Expr: &SearchAtom{
+			Field:    "EventId",
+			Patterns: []string{"1234"},
+		},
+	}
+
+	entry := &LogEntry{
+		Fields: map[string]string{
+			"EventId": "1234",
+		},
+	}
+
+	opts := &MatchOptions{EnableExplanation: true}
+	result := detection.Matches(entry, opts)
+
+	if !result.Matched {
+		t.Error("Expected match")
+	}
+	if result.Explanation == "" {
+		t.Error("Expected non-empty explanation")
+	}
+	if !strings.Contains(result.Explanation, "EventId") {
+		t.Error("Explanation should mention EventId field")
+	}
+	t.Logf("Explanation:\n%s", result.Explanation)
+}
+
+func TestExplainAndExpressionFailure(t *testing.T) {
+	detection := &Detection{
+		Expr: &AndExpr{
+			X: []Expr{
+				&SearchAtom{Field: "EventId", Patterns: []string{"1234"}},
+				&SearchAtom{Field: "User", Patterns: []string{"admin"}},
+			},
+		},
+	}
+
+	entry := &LogEntry{
+		Fields: map[string]string{
+			"EventId": "1234",
+			"User":    "guest",
+		},
+	}
+
+	opts := &MatchOptions{EnableExplanation: true}
+	result := detection.Matches(entry, opts)
+
+	if result.Matched {
+		t.Error("Expected no match")
+	}
+	if !strings.Contains(result.Explanation, "User") {
+		t.Error("Explanation should mention User field")
+	}
+	if !strings.Contains(result.Explanation, "✗") {
+		t.Error("Explanation should show failure symbol")
+	}
+	t.Logf("Explanation:\n%s", result.Explanation)
+}
+
+func TestExplainOrExpression(t *testing.T) {
+	detection := &Detection{
+		Expr: &OrExpr{
+			X: []Expr{
+				&SearchAtom{Field: "EventId", Patterns: []string{"1234"}},
+				&SearchAtom{Field: "EventId", Patterns: []string{"5678"}},
+			},
+		},
+	}
+
+	entry := &LogEntry{
+		Fields: map[string]string{
+			"EventId": "1234",
+		},
+	}
+
+	opts := &MatchOptions{EnableExplanation: true}
+	result := detection.Matches(entry, opts)
+
+	if !result.Matched {
+		t.Error("Expected match")
+	}
+	if !strings.Contains(result.Explanation, "[OR]") {
+		t.Error("Explanation should mention OR")
+	}
+	t.Logf("Explanation:\n%s", result.Explanation)
+}
+
+func TestExplainNotExpression(t *testing.T) {
+	detection := &Detection{
+		Expr: &NotExpr{
+			X: &SearchAtom{Field: "User", Patterns: []string{"admin"}},
+		},
+	}
+
+	entry := &LogEntry{
+		Fields: map[string]string{
+			"User": "guest",
+		},
+	}
+
+	opts := &MatchOptions{EnableExplanation: true}
+	result := detection.Matches(entry, opts)
+
+	if !result.Matched {
+		t.Error("Expected match (NOT admin)")
+	}
+	if !strings.Contains(result.Explanation, "[NOT]") {
+		t.Error("Explanation should mention NOT")
+	}
+	if !strings.Contains(result.Explanation, "negated") {
+		t.Error("Explanation should mention negation")
+	}
+	t.Logf("Explanation:\n%s", result.Explanation)
+}
+
+func TestExplainMissingField(t *testing.T) {
+	detection := &Detection{
+		Expr: &SearchAtom{
+			Field:    "MissingField",
+			Patterns: []string{"value"},
+		},
+	}
+
+	entry := &LogEntry{
+		Fields: map[string]string{
+			"OtherField": "other",
+		},
+	}
+
+	opts := &MatchOptions{EnableExplanation: true}
+	result := detection.Matches(entry, opts)
+
+	if result.Matched {
+		t.Error("Expected no match")
+	}
+	if !strings.Contains(result.Explanation, "not found") {
+		t.Error("Explanation should mention field not found")
+	}
+	t.Logf("Explanation:\n%s", result.Explanation)
+}
+
+func TestExplainCaseInsensitive(t *testing.T) {
+	detection := &Detection{
+		Expr: &SearchAtom{
+			Field:    "eventid",
+			Patterns: []string{"1234"},
+		},
+	}
+
+	entry := &LogEntry{
+		Fields: map[string]string{
+			"EventId": "1234",
+		},
+	}
+
+	opts := &MatchOptions{EnableExplanation: true}
+	result := detection.Matches(entry, opts)
+
+	if !result.Matched {
+		t.Error("Expected match (case-insensitive)")
+	}
+	if !strings.Contains(result.Explanation, "case-insensitive") {
+		t.Error("Explanation should mention case-insensitive match")
+	}
+	t.Logf("Explanation:\n%s", result.Explanation)
+}
+
+func TestExplainMessage(t *testing.T) {
+	detection := &Detection{
+		Expr: &SearchAtom{
+			Field:    "",
+			Patterns: []string{"*error*"},
+		},
+	}
+
+	entry := &LogEntry{
+		Message: "An error occurred",
+	}
+
+	opts := &MatchOptions{EnableExplanation: true}
+	result := detection.Matches(entry, opts)
+
+	if !result.Matched {
+		t.Error("Expected match on message")
+	}
+	if !strings.Contains(result.Explanation, "message") {
+		t.Error("Explanation should mention message matching")
+	}
+	t.Logf("Explanation:\n%s", result.Explanation)
+}
+
+func TestExplainDisabled(t *testing.T) {
+	detection := &Detection{
+		Expr: &SearchAtom{
+			Field:    "EventId",
+			Patterns: []string{"1234"},
+		},
+	}
+
+	entry := &LogEntry{
+		Fields: map[string]string{
+			"EventId": "1234",
+		},
+	}
+
+	opts := &MatchOptions{EnableExplanation: false}
+	result := detection.Matches(entry, opts)
+
+	if !result.Matched {
+		t.Error("Expected match")
+	}
+	if result.Explanation != "" {
+		t.Error("Expected empty explanation when disabled")
+	}
+}
+
+func TestExplainNamedExpression(t *testing.T) {
+	detection := &Detection{
+		Expr: &NamedExpr{
+			Name: "selection",
+			X: &SearchAtom{
+				Field:    "EventId",
+				Patterns: []string{"1234"},
+			},
+		},
+	}
+
+	entry := &LogEntry{
+		Fields: map[string]string{
+			"EventId": "1234",
+		},
+	}
+
+	opts := &MatchOptions{EnableExplanation: true}
+	result := detection.Matches(entry, opts)
+
+	if !result.Matched {
+		t.Error("Expected match")
+	}
+	if !strings.Contains(result.Explanation, "selection") {
+		t.Error("Explanation should mention named expression 'selection'")
+	}
+	t.Logf("Explanation:\n%s", result.Explanation)
+}
+
+func TestExplainComplexRule(t *testing.T) {
+	detection := &Detection{
+		Expr: &AndExpr{
+			X: []Expr{
+				&NamedExpr{
+					Name: "selection",
+					X: &SearchAtom{
+						Field:    "EventId",
+						Patterns: []string{"4624"},
+					},
+				},
+				&NotExpr{
+					X: &NamedExpr{
+						Name: "filter",
+						X: &SearchAtom{
+							Field:    "User",
+							Patterns: []string{"SYSTEM"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	entry := &LogEntry{
+		Fields: map[string]string{
+			"EventId": "4624",
+			"User":    "admin",
+		},
+	}
+
+	opts := &MatchOptions{EnableExplanation: true}
+	result := detection.Matches(entry, opts)
+
+	if !result.Matched {
+		t.Error("Expected match")
+	}
+	if !strings.Contains(result.Explanation, "selection") {
+		t.Error("Explanation should mention 'selection'")
+	}
+	if !strings.Contains(result.Explanation, "filter") {
+		t.Error("Explanation should mention 'filter'")
+	}
+	t.Logf("Explanation:\n%s", result.Explanation)
+}

--- a/sigma.go
+++ b/sigma.go
@@ -95,12 +95,19 @@ type LogEntry struct {
 	Fields  map[string]string
 }
 
+// MatchResult contains the result of evaluating a detection.
+type MatchResult struct {
+	Matched     bool
+	Explanation string
+}
+
 // MatchOptions are the parameters to [Detection.Matches] and [Expr].ExprMatches.
 type MatchOptions struct {
 	Placeholders map[string][]string
 	// FieldResolver provides optional custom field lookup logic.
 	// If nil, standard field lookup is used (exact match, then case-insensitive).
-	FieldResolver FieldResolver
+	FieldResolver     FieldResolver
+	EnableExplanation bool
 }
 
 // Detection describes the pattern that a [Rule] is matching on.
@@ -108,9 +115,18 @@ type Detection struct {
 	Expr Expr
 }
 
-// Matches reports whether the entry matches the detection's expression.
-func (d *Detection) Matches(entry *LogEntry, opts *MatchOptions) bool {
-	return d.Expr.ExprMatches(entry, opts)
+func (d *Detection) Matches(entry *LogEntry, opts *MatchOptions) MatchResult {
+	if opts == nil || !opts.EnableExplanation {
+		matched := d.Expr.ExprMatches(entry, opts)
+		return MatchResult{Matched: matched}
+	}
+
+	ctx := newExplanationContext()
+	matched := d.Expr.explainMatches(entry, opts, ctx)
+	return MatchResult{
+		Matched:     matched,
+		Explanation: ctx.Format(),
+	}
 }
 
 // An Expr is a sub-expression inside of a [Detection].
@@ -120,6 +136,7 @@ func (d *Detection) Matches(entry *LogEntry, opts *MatchOptions) bool {
 // from multiple goroutines.
 type Expr interface {
 	ExprMatches(*LogEntry, *MatchOptions) bool
+	explainMatches(*LogEntry, *MatchOptions, *explanationContext) bool
 }
 
 // NamedExpr is an [Expr] that has a name.
@@ -133,6 +150,16 @@ func (n *NamedExpr) ExprMatches(entry *LogEntry, opts *MatchOptions) bool {
 	return n.X.ExprMatches(entry, opts)
 }
 
+func (n *NamedExpr) explainMatches(entry *LogEntry, opts *MatchOptions, ctx *explanationContext) bool {
+	node := &traceNode{Type: "named", Name: n.Name}
+	ctx.push(node)
+	defer ctx.pop()
+
+	matched := n.X.explainMatches(entry, opts, ctx)
+	node.Matched = matched
+	return matched
+}
+
 // NotExpr is a negated [Expr].
 type NotExpr struct {
 	X Expr
@@ -140,6 +167,17 @@ type NotExpr struct {
 
 func (x *NotExpr) ExprMatches(entry *LogEntry, opts *MatchOptions) bool {
 	return !x.X.ExprMatches(entry, opts)
+}
+
+func (x *NotExpr) explainMatches(entry *LogEntry, opts *MatchOptions, ctx *explanationContext) bool {
+	node := &traceNode{Type: "not"}
+	ctx.push(node)
+	defer ctx.pop()
+
+	matched := x.X.explainMatches(entry, opts, ctx)
+	node.Matched = !matched
+	node.Reason = fmt.Sprintf("negated: %v → %v", matched, !matched)
+	return !matched
 }
 
 // AndExpr is an [Expr]
@@ -157,6 +195,26 @@ func (a *AndExpr) ExprMatches(entry *LogEntry, opts *MatchOptions) bool {
 	return true
 }
 
+func (a *AndExpr) explainMatches(entry *LogEntry, opts *MatchOptions, ctx *explanationContext) bool {
+	node := &traceNode{Type: "and"}
+	ctx.push(node)
+	defer ctx.pop()
+
+	allMatched := true
+	for i, x := range a.X {
+		matched := x.explainMatches(entry, opts, ctx)
+		if !matched {
+			allMatched = false
+			if node.Reason == "" {
+				node.Reason = fmt.Sprintf("child %d failed", i)
+			}
+		}
+	}
+
+	node.Matched = allMatched
+	return allMatched
+}
+
 // OrExpr is an [Expr]
 // that evaluates to true if at least one of its sub-expressions evaluate to true.
 type OrExpr struct {
@@ -170,6 +228,26 @@ func (o *OrExpr) ExprMatches(entry *LogEntry, opts *MatchOptions) bool {
 		}
 	}
 	return false
+}
+
+func (o *OrExpr) explainMatches(entry *LogEntry, opts *MatchOptions, ctx *explanationContext) bool {
+	node := &traceNode{Type: "or"}
+	ctx.push(node)
+	defer ctx.pop()
+
+	anyMatched := false
+	for i, x := range o.X {
+		matched := x.explainMatches(entry, opts, ctx)
+		if matched {
+			anyMatched = true
+			if node.Reason == "" {
+				node.Reason = fmt.Sprintf("child %d succeeded", i)
+			}
+		}
+	}
+
+	node.Matched = anyMatched
+	return anyMatched
 }
 
 // A SearchAtom is an [Expr] that matches against a single field.
@@ -324,6 +402,93 @@ func (atom *SearchAtom) ExprMatches(entry *LogEntry, opts *MatchOptions) bool {
 	}
 
 	// No matching field found
+	return false
+}
+
+func (atom *SearchAtom) explainMatches(entry *LogEntry, opts *MatchOptions, ctx *explanationContext) bool {
+	node := &traceNode{
+		Type:    "atom",
+		Field:   atom.Field,
+		Pattern: atom.Patterns,
+	}
+	ctx.push(node)
+	defer ctx.pop()
+
+	if err := atom.Validate(); err != nil {
+		node.Matched = false
+		node.Reason = fmt.Sprintf("validation failed: %v", err)
+		return false
+	}
+
+	var placeholders map[string][]string
+	if opts != nil {
+		placeholders = opts.Placeholders
+	}
+	compiled := atom.compile(placeholders)
+
+	if atom.Field == "" {
+		node.FieldValue = entry.Message
+		matched := compiled.matches(entry.Message)
+		node.Matched = matched
+		if matched {
+			node.Reason = "message matched pattern"
+		} else {
+			node.Reason = "message did not match pattern"
+		}
+		return matched
+	}
+
+	if opts != nil && opts.FieldResolver != nil {
+		values := opts.FieldResolver.Resolve(atom.Field, entry)
+		if len(values) == 0 {
+			node.Matched = false
+			node.Reason = "field resolver returned no values"
+			return false
+		}
+
+		for i, value := range values {
+			if compiled.matches(value) {
+				node.Matched = true
+				node.FieldValue = value
+				node.Reason = fmt.Sprintf("resolver value %d matched", i)
+				return true
+			}
+		}
+		node.Matched = false
+		node.FieldValue = fmt.Sprintf("%d values checked", len(values))
+		node.Reason = "none of the resolver values matched"
+		return false
+	}
+
+	if v, ok := entry.Fields[atom.Field]; ok {
+		node.FieldValue = v
+		matched := compiled.matches(v)
+		node.Matched = matched
+		if matched {
+			node.Reason = "field value matched (exact)"
+		} else {
+			node.Reason = "field value did not match"
+		}
+		return matched
+	}
+
+	wantField := strings.ToLower(atom.Field)
+	for k, v := range entry.Fields {
+		if strings.ToLower(k) == wantField {
+			node.FieldValue = v
+			matched := compiled.matches(v)
+			node.Matched = matched
+			if matched {
+				node.Reason = fmt.Sprintf("field value matched (case-insensitive: %s)", k)
+			} else {
+				node.Reason = "field value did not match"
+			}
+			return matched
+		}
+	}
+
+	node.Matched = false
+	node.Reason = "field not found"
 	return false
 }
 

--- a/sigma_test.go
+++ b/sigma_test.go
@@ -330,7 +330,7 @@ func TestDetectionMatches(t *testing.T) {
 			t.Errorf("%s: %v", test.filename, err)
 			continue
 		}
-		got := rule.Detection.Matches(test.entry, test.options)
+		got := rule.Detection.Matches(test.entry, test.options).Matched
 		if got != test.want {
 			t.Errorf("ParseRule(%q).Detection.Matches(%+v, %+v) = %t; want %t",
 				test.filename, test.entry, test.options, got, test.want)


### PR DESCRIPTION
Add optional explanation capability that shows why a Sigma rule matched or didn't match. The explanation provides a complete trace of the expression tree evaluation with human-readable output.

BREAKING CHANGE: Detection.Matches() now returns MatchResult struct instead of bool. Callers must access the .Matched field:

Before:
  if rule.Detection.Matches(entry, opts) { ... }

After:
  if rule.Detection.Matches(entry, opts).Matched { ... }

Key features:
- Opt-in via MatchOptions.EnableExplanation flag
- Full trace showing all expression evaluations (AND/OR/NOT/atoms)
- Shows field values, patterns, and reasons for match/no-match
- No performance impact when disabled (fast path preserved)
- Thread-safe with per-call context

Changes:
- Add MatchResult type with Matched bool and Explanation string
- Add EnableExplanation flag to MatchOptions
- Add explainMatches() method to Expr interface and all implementations
- Create explanation.go with trace building and formatting logic
- Update all existing tests to use .Matched
- Add comprehensive explanation_test.go with 10 test cases
- Add Example_explain() demonstrating usage

Example output:
[AND] ✗ - child 1 failed
  [EventId] ✓ Value: "1234" Pattern: [1234] Reason: field value matched (exact) [User] ✗ Value: "guest" Pattern: [admin] Reason: field value did not match